### PR TITLE
Fix API header handling

### DIFF
--- a/lib/core/service/http_service.dart
+++ b/lib/core/service/http_service.dart
@@ -45,6 +45,9 @@ final class HttpService implements IHttpService {
   }) async {
     try {
       await _changeDioOptionsAsync();
+      if (headers != null && headers.isNotEmpty) {
+        _dio.options.headers.addAll(headers);
+      }
       final Response response = await _dio.get(url);
       return _createHttpResponseFromResponse(response);
     } catch (error) {


### PR DESCRIPTION
## Summary
- ensure custom headers are sent with HTTP GET requests

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6845ecd90a1c83319f9978b4296d6064